### PR TITLE
Add configurable measurement flags to task processing

### DIFF
--- a/include/anacal/task.h
+++ b/include/anacal/task.h
@@ -153,8 +153,7 @@ public:
         int num_epochs=3,
         bool force_size=false,
         bool force_center=false,
-        double fpfs_c0=1.0,
-        bool do_fpfs=true
+        double fpfs_c0=1.0
     ) : scale(scale), sigma_arcsec(sigma_arcsec), snr_peak_min(snr_peak_min),
         omega_f(omega_f), v_min(v_min), omega_v(omega_v),
         p_min(p_min), omega_p(omega_p),
@@ -163,7 +162,7 @@ public:
         num_epochs(num_epochs), fitter(
             scale, sigma_arcsec, stamp_size,
             force_size, force_center,
-            fpfs_c0, do_fpfs
+            fpfs_c0
         )
     {
         if (stamp_size % 2 != 0 ) {
@@ -274,7 +273,9 @@ public:
         const std::optional<py::array_t<table::galRow>>& detection=std::nullopt,
         const std::optional<py::array_t<double>>& noise_array=std::nullopt,
         const std::optional<py::array_t<int16_t>>& mask_array=std::nullopt,
-        double a_ini=0.2
+        double a_ini=0.2,
+        bool do_measure=true,
+        bool do_fpfs=true
     ) {
 
         double variance_use;
@@ -318,96 +319,100 @@ public:
             }
         }
 
-        auto compute_flux_errors = [&](const py::array_t<double>& psf) {
-            const double flux_gauss0_var = gaussian_flux_variance(
-                psf,
-                0.0,
-                this->sigma_arcsec,
-                this->scale
-            );
-            const double flux_gauss2_var = gaussian_flux_variance(
-                psf,
-                0.2,
-                this->sigma_arcsec,
-                this->scale
-            );
-            const double flux_gauss4_var = gaussian_flux_variance(
-                psf,
-                0.4,
-                this->sigma_arcsec,
-                this->scale
-            );
-            std::array<double, 3> errs{};
-            errs[0] = std::sqrt(std::max(0.0, flux_gauss0_var) * variance_use);
-            errs[1] = std::sqrt(std::max(0.0, flux_gauss2_var) * variance_use);
-            errs[2] = std::sqrt(std::max(0.0, flux_gauss4_var) * variance_use);
-            return errs;
-        };
+        this->fitter.do_fpfs = do_fpfs;
 
-        for (geometry::block & block: block_list) {
-            prepare_indices(
-                catalog,
-                block
-            );
+        if (do_measure) {
+            auto compute_flux_errors = [&](const py::array_t<double>& psf) {
+                const double flux_gauss0_var = gaussian_flux_variance(
+                    psf,
+                    0.0,
+                    this->sigma_arcsec,
+                    this->scale
+                );
+                const double flux_gauss2_var = gaussian_flux_variance(
+                    psf,
+                    0.2,
+                    this->sigma_arcsec,
+                    this->scale
+                );
+                const double flux_gauss4_var = gaussian_flux_variance(
+                    psf,
+                    0.4,
+                    this->sigma_arcsec,
+                    this->scale
+                );
+                std::array<double, 3> errs{};
+                errs[0] = std::sqrt(std::max(0.0, flux_gauss0_var) * variance_use);
+                errs[1] = std::sqrt(std::max(0.0, flux_gauss2_var) * variance_use);
+                errs[2] = std::sqrt(std::max(0.0, flux_gauss4_var) * variance_use);
+                return errs;
+            };
 
-            if (block.indices.empty()) {
-                continue;
+            for (geometry::block & block: block_list) {
+                prepare_indices(
+                    catalog,
+                    block
+                );
+
+                if (block.indices.empty()) {
+                    continue;
+                }
+
+                py::array_t<double> psf;
+                if (
+                    block.psf_array.ndim() == 2 &&
+                    psf_array.shape(0) == this->stamp_size &&
+                    psf_array.shape(1) == this->stamp_size
+                ) {
+                    psf = block.psf_array;
+                } else {
+                    psf = psf_array;
+                }
+                const std::array<double, 3> block_flux_errs = compute_flux_errors(
+                    psf
+                );
+                for (std::size_t idx : block.indices) {
+                    catalog[idx].flux_gauss0_err = block_flux_errs[0];
+                    catalog[idx].flux_gauss2_err = block_flux_errs[1];
+                    catalog[idx].flux_gauss4_err = block_flux_errs[2];
+                }
             }
 
-            py::array_t<double> psf;
-            if (
-                block.psf_array.ndim() == 2 &&
-                psf_array.shape(0) == this->stamp_size &&
-                psf_array.shape(1) == this->stamp_size
-            ) {
-                psf = block.psf_array;
-            } else {
-                psf = psf_array;
+            std::vector<table::galNumber> catalog_model = catalog;
+            for (table::galNumber & src : catalog_model) {
+                src.model.F = src.model.F * src.wdet;
             }
-            const std::array<double, 3> block_flux_errs = compute_flux_errors(
-                psf
-            );
-            for (std::size_t idx : block.indices) {
-                catalog[idx].flux_gauss0_err = block_flux_errs[0];
-                catalog[idx].flux_gauss2_err = block_flux_errs[1];
-                catalog[idx].flux_gauss4_err = block_flux_errs[2];
+            for (const geometry::block & block: block_list) {
+                py::array_t<double> psf;
+                if (
+                    block.psf_array.ndim() == 2 &&
+                    psf_array.shape(0) == this->stamp_size &&
+                    psf_array.shape(1) == this->stamp_size
+                ) {
+                    psf = block.psf_array;
+                } else {
+                    psf = psf_array;
+                }
+                measure_block(
+                    catalog,
+                    catalog_model,
+                    img_array,
+                    psf,
+                    variance_use,
+                    block,
+                    noise_array,
+                    0 // run_id
+                );
             }
-        }
 
-        std::vector<table::galNumber> catalog_model = catalog;
-        for (table::galNumber & src : catalog_model) {
-            src.model.F = src.model.F * src.wdet;
-        }
-        for (const geometry::block & block: block_list) {
-            py::array_t<double> psf;
-            if (
-                block.psf_array.ndim() == 2 &&
-                psf_array.shape(0) == this->stamp_size &&
-                psf_array.shape(1) == this->stamp_size
-            ) {
-                psf = block.psf_array;
-            } else {
-                psf = psf_array;
+            if (mask_array.has_value()) {
+                mask::add_pixel_mask_column(
+                    catalog,
+                    *mask_array,
+                    this->sigma_arcsec_det * 1.5,
+                    scale
+                );
             }
-            measure_block(
-                catalog,
-                catalog_model,
-                img_array,
-                psf,
-                variance_use,
-                block,
-                noise_array,
-                0 // run_id
-            );
-        }
-
-        if (mask_array.has_value()) {
-            mask::add_pixel_mask_column(
-                catalog,
-                *mask_array,
-                this->sigma_arcsec_det * 1.5,
-                scale
-            );
         }
         return table::objlist_to_array(catalog);
     };

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -15,7 +15,7 @@ pyExportTask(py::module_& m) {
             double, double, double, double,
             const std::optional<ngmix::modelPrior>,
             int, int, int,
-            bool, bool, double, bool
+            bool, bool, double
             >(),
             py::arg("scale"),
             py::arg("sigma_arcsec"),
@@ -31,8 +31,7 @@ pyExportTask(py::module_& m) {
             py::arg("num_epochs")=3,
             py::arg("force_size")=false,
             py::arg("force_center")=false,
-            py::arg("fpfs_c0")=1.0,
-            py::arg("do_fpfs")=true
+            py::arg("fpfs_c0")=1.0
         )
         .def("process_image", &Task::process_image,
             "process image with PSF array",
@@ -43,7 +42,9 @@ pyExportTask(py::module_& m) {
             py::arg("detection")=py::none(),
             py::arg("noise_array")=py::none(),
             py::arg("mask_array")=py::none(),
-            py::arg("a_ini")=0.2
+            py::arg("a_ini")=0.2,
+            py::arg("do_measure")=true,
+            py::arg("do_fpfs")=true
         );
     task.def(
         "gaussian_flux_variance",

--- a/tests/task/test_flux_variance.py
+++ b/tests/task/test_flux_variance.py
@@ -219,6 +219,17 @@ def test_flux_variance():
         rtol=1e-5,
         atol=1e-6,
     )
+    catalog_no_fpfs = det_task.process_image(
+        gal_array,
+        psf_array,
+        variance=noise_std**2.0,
+        block_list=blocks,
+        do_fpfs=False,
+    )
+    np.testing.assert_allclose(
+        catalog_no_fpfs["wsel"],
+        catalog_no_fpfs["wdet"],
+    )
     np.testing.assert_allclose(
         catalog5["flux_gauss2_err"][0],
         np.sqrt(flux_var4),


### PR DESCRIPTION
## Summary
- add a `do_measure` flag to `Task::process_image` (default true) to toggle measurement-related steps
- move FPFS toggling from `Task` initialization to a new `do_fpfs` flag on `process_image`, updating the fitter configuration and tests
- expose the new `do_fpfs` argument through the Python binding for `Task` and ensure selection weights reflect the flag when disabled

## Testing
- `pytest tests/task/test_flux_variance.py` *(fails: pytest configuration expects nbval/nbval-lax plugins which are unavailable in the environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69462a0d0de0832c946a7744433654f7)